### PR TITLE
Add 'error' event handler to `http.request`

### DIFF
--- a/node/main.js
+++ b/node/main.js
@@ -43,6 +43,13 @@ var StatHat = {
                                 callback(res.statusCode, chunk);
                         });
                 });
+
+                request.on('error', function(e) {
+                        if (!e) e = {};
+                        //console.error("StatHat HTTP error: "+e.message);
+                        callback(600,e.message);
+                });
+                
                 request.write(qs);
 
                 request.end();


### PR DESCRIPTION
Unhandled 'error' events cause NodeJS servers to crash - the use of `uncaughtException` is discouraged since it can mask serious underlying problems.
