### PR TITLE
Catching exceptions in RequestCallback

### DIFF
--- a/csharp/StatHat.cs
+++ b/csharp/StatHat.cs
@@ -311,17 +311,24 @@ namespace StatHat
             }
             private void RequestCallback(IAsyncResult asyncResult)
             {
-
-                string postData = "";
-                foreach (string key in this.Parameters.Keys)
+                try
                 {
-                    postData += encodeUriComponent(key) + "=" + encodeUriComponent(this.Parameters[key]) + "&";
+                    string postData = "";
+                    foreach (string key in this.Parameters.Keys)
+                    {
+                        postData += encodeUriComponent(key) + "=" + encodeUriComponent(this.Parameters[key]) + "&";
+                    }
+                    Stream newStream = Request.EndGetRequestStream(asyncResult);
+                    StreamWriter streamWriter = new StreamWriter(newStream);
+                    streamWriter.Write(postData);
+                    streamWriter.Close();
+                    this.Request.BeginGetResponse(this.ResponseCallback, this.Request);
                 }
-                Stream newStream = Request.EndGetRequestStream(asyncResult);
-                StreamWriter streamWriter = new StreamWriter(newStream);
-                streamWriter.Write(postData);
-                streamWriter.Close();
-                this.Request.BeginGetResponse(this.ResponseCallback, this.Request);
+                catch (Exception e)
+                {
+                    this.Reply(e.Message);
+                }
+                finally { }
             }
 
             private string encodeUriComponent(string s)


### PR DESCRIPTION
Hi
There seem to be an issue with the lib. Some users had it with the app we created, and i was able to reproduce it recently.
When the device has no internet connection, the request will fail. There is a request callback, and a response callback, both are async. The ResponseCallback exceptions are catched, but the RequestCallback exceptions are not. Even if you catch all exceptions around the stathat library calls, the fact that the callbacks are run in another thread makes the exception non catched and the app will crash.
Hope this helps
Jerome