### PR TITLE
Data response from server isn't zero terminated is it?

### DIFF
--- a/objc/StatHat.m
+++ b/objc/StatHat.m
@@ -116,7 +116,7 @@
                 return;
         }
 
-        [_body appendString:[NSString stringWithUTF8String:[data bytes]]];
+  [_body appendString:[[NSString alloc] initWithBytes:[data bytes] length:[data length] encoding:NSUTF8StringEncoding]];
 }
 
 - (void)connection:(NSURLConnection *)connection didFailWithError:(NSError *)error


### PR DESCRIPTION
Fix for a crash that I am getting on Yosemite.

It seems like the code was assuming that the returned string was zero terminated, and I don't think it is...
