### PR TITLE
Support Python 3

### DIFF
--- a/python/stathat.py
+++ b/python/stathat.py
@@ -1,12 +1,13 @@
-import urllib
-import urllib2
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
 
 class StatHat:
 
         def http_post(self, path, data):
-                pdata = urllib.urlencode(data)
-                req = urllib2.Request('http://api.stathat.com' + path, pdata)
-                resp = urllib2.urlopen(req)
+                pdata = urlencode(data)
+                pdata = pdata.encode('ascii')
+                req = Request('http://api.stathat.com' + path, pdata)
+                resp = urlopen(req)
                 return resp.read()
 
         def post_value(self, user_key, stat_key, value, timestamp=None):


### PR DESCRIPTION
Python 2 sunset on [1 January 2020](https://www.python.org/doc/sunset-python-2/)

[_The_ `urllib2` _module has been split across several modules in Python 3_](https://docs.python.org/2/library/urllib2.html)

Signed-off-by: Christian Heinrich <christian.heinrich@cmlh.id.au>